### PR TITLE
add EXTERNAL_PATH env

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -6,6 +6,14 @@
 
 ---
 
+## 1.6.1
+
+`2023-02-05`
+
+[#22](https://github.com/guMcrey/version-rocket/issues/22)
+- 🆕 generate-version-file added the `EXTERNAL_PATH` environment variable, which supports passing in the path of a file. It is recommended to use it when a large amount of additional information needs to be written into `version.json`. When `EXTERNAL` and `EXTERNAL_PATH` are set at the same time, the priority is lower than that of `EXTERNAL`
+- 💄 更新 README.md 和 README.zh-CN.md 文档
+
 ## 1.6.0
 
 `2023-02-04`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -6,12 +6,21 @@
 
 ---
 
+## 1.6.1
+
+`2023-02-05`
+
+[#22](https://github.com/guMcrey/version-rocket/issues/22)
+- 🆕 generate-version-file 新增 `EXTERNAL_PATH` 环境变量，支持传入文本文件路径，推荐在需要将大量额外信息写入 `version.json` 中时使用. 当同时设置了 `EXTERNAL` 和 `EXTERNAL_PATH` 时，优先级低于 `EXTERNAL`。
+- 💄 更新 README.md 和 README.zh-CN.md 文档
+
+
 ## 1.6.0
 
 `2023-02-04`
 
 [#22](https://github.com/guMcrey/version-rocket/issues/22)
-- 🆕 generate-version-file 新增 EXTERNAL 坏境变量，可用于在自定义弹窗 UI 时展示更丰富内容。如当前版本更新内容或其他信息
+- 🆕 generate-version-file 新增 `EXTERNAL` 环境变量，可用于在自定义弹窗 UI 时展示更丰富内容。如当前版本更新内容或其他信息
 - 💄 更新 README.md 和 README.zh-CN.md 文档
 
 ## 1.5.0

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Step 2: after executing the `generate-version-file` custom command, generate the
 
 - `EXTERNAL` (optional): when you want to save more information to `version.json`, such as the modified content of the current version or other things that need to be displayed on the pop-up (used in onVersionUpdate custom UI) `v1.6.0`
 
+- `EXTERNAL_PATH` (optional)：Accepts a file path, recommended when a lot of extra information needs to be written to `version.json`. When both `EXTERNAL` and `EXTERNAL_PATH` are set, the priority is lower than `EXTERNAL`（used in onVersionUpdate custom UI）`v1.6.1`
+
+**VERSION usage**
+
 ```javascript
 // package.json
 
@@ -139,7 +143,7 @@ Step 2: after executing the `generate-version-file` custom command, generate the
 
 ```
 
-**EXTERNAL usage** `v1.6.0`
+**EXTERNAL `v1.6.0` and EXTERNAL_PATH `v1.6.1` usage**
 
 JSON format please use this tool to escape [click here](https://codebeautify.org/json-encode-online)
 
@@ -157,15 +161,32 @@ JSON format please use this tool to escape [click here](https://codebeautify.org
     "generate:version": "EXTERNAL='some text' generate-version-file dist public"
     // Mac or Linux (JSON text)
     "generate:version": "EXTERNAL='{\"update\":\"fix bugs\",\"content\":\"some tips\"}' generate-version-file dist public"
+    // Mac or Linux （JSON file, e.g. version-external.json）
+    "generate:version": "EXTERNAL_PATH=version-external.json generate-version-file dist public"
     // Windows (simple text)
     "generate:version": "set EXTERNAL=some text && generate-version-file dist public"
     // Windows (JSON text)
     "generate:version": "set EXTERNAL={\"update\":\"fix bugs\",\"content\":\"some tips\"} && generate-version-file dist public"
+    // Windows （JSON file, e.g. version-external.json）
+    "generate:version": "set EXTERNAL_PATH=version-external.json && generate-version-file dist public"
     ...
   },
   ...
 }
 
+```
+
+```json
+// version-external.json
+
+{
+    "update": [
+        "fix some bugs",
+        "improve home page",
+        "update docs"
+    ],
+    "content": "please update to latest version"
+}
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ JSON format please use this tool to escape [click here](https://codebeautify.org
 
 ```
 
-```json
+```javascript
 // version-external.json
 
 {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -172,7 +172,7 @@ JSON 格式可以通过 [这里](https://codebeautify.org/json-encode-online) �
 
 ```
 
-```json
+```javascript
 // version-external.json 示例
 
 {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -113,6 +113,9 @@ unCheckVersion({closeDialog: false})
 - `VERSION` (参数可选): 需要**自定义 version** 时传入, 默认取 package.json 的 version 字段
 - 文件输出目录 (参数可选): 需要**自定义 version.json 输出目录**时传入, 默认为 dist 目录
 - `EXTERNAL` (参数可选)：希望将更多信息存到 `version.json` 中时传入，如当前版本的修改内容或其他需要展示在提示弹窗上时 （用于 onVersionUpdate 自定义 UI 时）`v1.6.0`
+- `EXTERNAL_PATH` (参数可选)：接收一个文件路径, 推荐在需要将大量额外信息写入 `version.json` 中时使用. 当同时设置了 `EXTERNAL` 和 `EXTERNAL_PATH` 时，优先级低于 `EXTERNAL` （用于 onVersionUpdate 自定义 UI 时）`v1.6.1`
+
+**VERSION 环境变量设置方式**
 
 ```javascript
 // package.json
@@ -136,7 +139,7 @@ unCheckVersion({closeDialog: false})
 
 ```
 
-**EXTERNAL 环境变量设置方式** `v1.6.0`
+**EXTERNAL `v1.6.0` 和 EXTERNAL_PATH `v1.6.1` 环境变量设置方式**
 
 JSON 格式可以通过 [这里](https://codebeautify.org/json-encode-online) 转义后再使用
 
@@ -154,15 +157,32 @@ JSON 格式可以通过 [这里](https://codebeautify.org/json-encode-online) �
     "generate:version": "EXTERNAL='some text' generate-version-file dist public"
     // Mac 或 Linux 系统 （JSON 文本）
     "generate:version": "EXTERNAL='{\"update\":\"fix bugs\",\"content\":\"some tips\"}' generate-version-file dist public"
+    // Mac 或 Linux 系统 （JSON 文件, 如 version-external.json）
+    "generate:version": "EXTERNAL_PATH=version-external.json generate-version-file dist public"
     // Windows 系统 (简单文本)
     "generate:version": "set EXTERNAL=some text && generate-version-file dist public"
     // Windows 系统 (JSON 文本)
     "generate:version": "set EXTERNAL={\"update\":\"fix bugs\",\"content\":\"some tips\"} && generate-version-file dist public"
+    // Windows 系统 （JSON 文件, 如 version-external.json）
+    "generate:version": "set EXTERNAL_PATH=version-external.json && generate-version-file dist public"
     ...
   },
   ...
 }
 
+```
+
+```json
+// version-external.json 示例
+
+{
+    "update": [
+        "fix some bugs",
+        "improve home page",
+        "update docs"
+    ],
+    "content": "please update to latest version"
+}
 ```
 
 <details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "version-rocket",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "version-rocket",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "version-rocket",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Tools to check version monitoring (updates) for web application. web 应用版本监测(更新)工具",
   "main": "index.js",
   "scripts": {

--- a/scripts/createVersionFile.js
+++ b/scripts/createVersionFile.js
@@ -10,12 +10,15 @@ const path = require('path');
 const outputDir = process.argv.length > 2 ? process.argv.splice(2) : ['dist']
 
 const getExternal = () => {
-  const external = process.env.EXTERNAL || ''
+  const externalJSONPath = process.env.EXTERNAL_PATH?.trim() ? path.join(process.cwd(), process.env.EXTERNAL_PATH.trim()) : '';
+  const externalJSONObject = externalJSONPath ? fs.readFileSync(externalJSONPath).toString() : '';
+  const external = process.env.EXTERNAL?.trim() || externalJSONObject;
+
   try {
     JSON.parse(external)
     return external
   } catch (error) {
-    return `"${external.trim()}"`
+    return `"${external}"`
   }
 }
 


### PR DESCRIPTION
[#22](https://github.com/guMcrey/version-rocket/issues/22)
- 🆕 generate-version-file added the `EXTERNAL_PATH` environment variable, which supports passing in the path of a file. It is recommended to use it when a large amount of additional information needs to be written into `version.json`. When `EXTERNAL` and `EXTERNAL_PATH` are set at the same time, the priority is lower than that of `EXTERNAL`
- 💄 更新 README.md 和 README.zh-CN.md 文档